### PR TITLE
Test run Selected Vertex on top and larger

### DIFF
--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2696,7 +2696,8 @@ void QgsVertexTool::setHighlightedVertices( const QList<Vertex> &listVertices, H
 
     QgsVertexMarker *marker = new QgsVertexMarker( canvas() );
     marker->setIconType( QgsVertexMarker::ICON_CIRCLE );
-    marker->setIconSize( QgsGuiUtils::scaleIconSize( 10 ) );
+    marker->setZValue( marker->zValue() + 1 );
+    marker->setIconSize( QgsGuiUtils::scaleIconSize( 12 ) );
     marker->setPenWidth( QgsGuiUtils::scaleIconSize( 2 ) );
     marker->setColor( Qt::blue );
     marker->setCenter( toMapCoordinates( vertex.layer, geom.vertexAt( vertex.vertexId ) ) );


### PR DESCRIPTION
## Description
Adds a z order to vertex selection so that a selected vertex is always visible. Also increases the selected vertex size so that overlapping vertices are more obvious when only one is selected. While this is much better than the previous behavior the size change revealed that when vertices are selected using a mouse on the canvas they still draw the unselected vertex style underneath the selected style.  
![image](https://github.com/user-attachments/assets/fdf54c44-f2d7-4507-857a-9691e146752b) rather than only the selected vertex style when selected in the table 
![image](https://github.com/user-attachments/assets/d9b41527-f5d1-4148-82b0-ad3f83b36174). I was not able to figure out how to fix that issue. 

Fixes #54034 


<!--
  BEFORE HITTING SUBMIT -- Please BUILD AND TEST your changes thoroughly. This is YOUR responsibility! Do NOT rely on the QGIS code maintainers to do this for you!!

  IMPORTANT NOTES FOR FIRST TIME CONTRIBUTORS
  ===========================================

  Congratulations, you are about to make a pull request to QGIS! To make this as easy and pleasurable for everyone, please take the time to read these lines before opening the pull request.

  Include a few sentences describing the overall goals for this pull request (PR). If applicable also add screenshots or - even better - screencasts.
  Include both: *what* you changed and *why* you changed it.

  If this is a pull request that adds new functionality which needs documentation, give an especially detailed explanation.
  In this case, start with a short abstract and then write some text that can be copied 1:1 to the documentation in the best case.

  Also mention if you think this PR needs to be backported. And list relevant or fixed issues.

------------------------

  Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by checking the following list.
  Feel free to ask in a comment if you have troubles with any of them.

  - Commit messages are descriptive and explain the rationale for changes.

  - Commits which fix bugs include `Fixes #11111` at the bottom of the commit message. If this is your first pull request and you forgot to do this, write the same statement into this text field with the pull request description.

  - New unit tests have been added for relevant changes

  - you have read the QGIS Developer Guide (https://docs.qgis.org/testing/en/docs/developers_guide/index.html) and your PR complies with its QGIS Coding Standards
-->
